### PR TITLE
DisplayDate responsive for both sm and md screens

### DIFF
--- a/src/components/DisplayDate.jsx
+++ b/src/components/DisplayDate.jsx
@@ -1,12 +1,25 @@
-import { Center, Title } from "@mantine/core";
+import { Center, MediaQuery, Title } from "@mantine/core";
 import { COLORS } from "../constants/constant";
 
 const DisplayDate = () => {
   return (
     <Center>
-      <Title radius={"sm"} mb={"xl"} pt={"sm"} color={COLORS.DISPLAYDATE}>
-        {new Date().toDateString()}
-      </Title>
+      <MediaQuery smallerThan={"md"} styles={{ display: "none" }}>
+        <Title
+          radius={"sm"}
+          fw={"400"}
+          mb={"xl"}
+          pt={"sm"}
+          color={COLORS.DISPLAY_DATE}
+        >
+          {new Date().toDateString()}
+        </Title>
+      </MediaQuery>
+      <MediaQuery largerThan={"md"} styles={{ display: "none" }}>
+        <Title order={2} fw={"400"} mb={"sm"} color={COLORS.DISPLAY_DATE}>
+          {new Date().toDateString()}
+        </Title>
+      </MediaQuery>
     </Center>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,11 @@
-import { AppShell, Header, Title, Navbar } from "@mantine/core";
+import {
+  AppShell,
+  Header,
+  Title,
+  Navbar,
+  ThemeIcon,
+  MediaQuery,
+} from "@mantine/core";
 import { useEffect, useState } from "react";
 import AddTaskForm from "../components/AddTaskForm";
 import TasksList from "../components/TasksList";
@@ -134,8 +141,16 @@ const Home = () => {
     <>
       <AppShell
         padding="xl"
+        navbarOffsetBreakpoint={"md"}
         navbar={
-          <Navbar width={{ base: 200 }} height={"full"} p="xl" bg={"gray.2"}>
+          <Navbar
+            width={{ base: 200 }}
+            hiddenBreakpoint={"md"}
+            height={"full"}
+            p="xl"
+            bg={"gray.2"}
+            hidden={"true"}
+          >
             <Navbar.Section grow mt={"120%"}>
               <FilterByCompletedStatus setFilter={setCompletedStatusFilter} />
             </Navbar.Section>


### PR DESCRIPTION
- At first, needed to remove the sidebar containing the filterCompletedByStatus.jsx component for sm and md screens as the display for md and sm screens does not include it. This component will be added to the bottom of the todo list later.
- Refactored DisplayDate into different sizes for sm and md screens